### PR TITLE
Examples of container classes

### DIFF
--- a/lib/python/radio_simus/container_examples/__main__.py
+++ b/lib/python/radio_simus/container_examples/__main__.py
@@ -1,0 +1,15 @@
+from .namedtuple import RawShower, TypedShower
+from .property import CheckedShower
+
+import astropy.units as u
+
+
+if __name__ == "__main__":
+    raw = RawShower(primary = "p", energy = 1E+19 * u.eV)
+    print("This is a raw shower: ", raw)
+
+    typed = TypedShower(primary = "Fe", energy = 1E+03 * u.m)
+    print("This is a typed shower: ", typed)
+
+    checked = CheckedShower(primary = "tau-", energy = 1E+00 * u.J)
+    print("This is a checked shower: ", checked)

--- a/lib/python/radio_simus/container_examples/__main__.py
+++ b/lib/python/radio_simus/container_examples/__main__.py
@@ -1,5 +1,5 @@
 from .namedtuple import RawShower, TypedShower
-from .property import CheckedShower
+from .property import CheckedShower, SimulatedShower
 
 import astropy.units as u
 
@@ -13,3 +13,7 @@ if __name__ == "__main__":
 
     checked = CheckedShower(primary = "tau-", energy = 1E+00 * u.J)
     print("This is a checked shower: ", checked)
+
+    simulated = SimulatedShower(primary = "tau-", energy = 1E+19 * u.eV,
+                                simulation="ZHAires")
+    print("This is a simulated shower: ", simulated)

--- a/lib/python/radio_simus/container_examples/namedtuple.py
+++ b/lib/python/radio_simus/container_examples/namedtuple.py
@@ -1,0 +1,42 @@
+from collections import namedtuple
+
+"""Example of raw shower container
+
+1. It is a tuple, i.e. it is immutable. Attributes can only be set at init.
+   They can't be modfied afterwards. Note that there are extra packages on PyPI
+   that provide mutable named containers, e.g. `recordclass`.
+
+2. The fields can be accessed as a tuple or as attributes, e.g. `shower.energy`.
+
+3. There is no cross-check when getting or setting a field.
+
+4. All atributes are set to optionnal by providing default values.
+"""
+RawShower = namedtuple("RawShower",
+                       ("showerID", "primary", "energy", "zenith", "azimuth"),
+                       defaults = 5 * (None,))
+
+
+import astropy.units as u
+from typing import NamedTuple, Optional
+
+"""Example of staticaly typed shower
+
+1. As previously, it is an immutable container. The fields can be accessed as a
+   tuple or as attributes.
+
+2. There is no runtime cross-check when getting or setting a field. However,
+   you can run a static analyzer like `mypy` in order to detect wrong type
+   usages.  Note that while the static check can ensure that a field, e.g. the
+   energy, is an astropy.Quantity (i.e. has a unit), it can not check for a
+   specific unit.  E.g. the energy can be given with unit meters.
+
+3. All atributes are set to optionnal using the explicit `Optional` type.
+"""
+class TypedShower(NamedTuple):
+    """Represents a particle shower"""
+    showerID: Optional[str] = None
+    primary: Optional[str] = None
+    energy: Optional[u.Quantity] = None
+    zenith: Optional[u.Quantity] = None
+    azimuth: Optional[u.Quantity] = None

--- a/lib/python/radio_simus/container_examples/property.py
+++ b/lib/python/radio_simus/container_examples/property.py
@@ -16,15 +16,16 @@ class CheckedShower():
     2. In addition using the @property class decorator we can perform runtime
        checks when an instance attribute is modified.
     """
+
+    _attributes = ["showerID", "primary", "energy", "zenith", "azimuth"]
+
+
     def __init__(self, **kwargs):
         self.__showerID: Optional[str] = None
         self.__primary: Optional[str] = None
         self.__energy: Optional[u.Quantity] = None
         self.__zenith: Optional[u.Quantity] = None
         self.__azimuth: Optional[u.Quantity] = None
-
-        self._attributes = ("showerID", "primary", "energy", "zenith",
-                            "azimuth")
 
         for attr, value in kwargs.items():
             if attr not in self._attributes:
@@ -35,7 +36,7 @@ class CheckedShower():
     def __str__(self) -> str:
         attributes = ", ".join([attr + "=" + repr(getattr(self, attr))
                                 for attr in self._attributes])
-        return f"CheckedShower({attributes})"
+        return f"{self.__class__.__name__}({attributes})"
 
 
     @staticmethod
@@ -97,3 +98,27 @@ class CheckedShower():
     def azimuth(self, value: u.Quantity):
         self._assert_not_set(self.__azimuth)
         self.__azimuth = value.to(u.deg)
+
+
+class SimulatedShower(CheckedShower):
+    """An example of extended class
+    """
+
+    _attributes = CheckedShower._attributes + ["simulation",]
+
+
+    def __init__(self, **kwargs):
+        self.__simulation: Optional[str] = None
+
+        super().__init__(**kwargs)
+
+
+    @property
+    def simulation(self) -> str:
+        """The simulation tag"""
+        return self.__simulation
+
+    @simulation.setter
+    def simulation(self, value: str):
+        self._assert_not_set(self.__simulation)
+        self.__simulation = value

--- a/lib/python/radio_simus/container_examples/property.py
+++ b/lib/python/radio_simus/container_examples/property.py
@@ -1,0 +1,99 @@
+import astropy.units as u
+from typing import Optional
+
+
+class AlreadySet(Exception):
+    """Raised when attempting to re-set an already set attribute"""
+    pass
+
+
+class CheckedShower():
+    """An example of a mutable container with both static and runtime checks
+
+    1. A static analyses can be done with mypy. It will ensure that the proper
+       types are used as arguments when setting the shower attributes.
+
+    2. In addition using the @property class decorator we can perform runtime
+       checks when an instance attribute is modified.
+    """
+    def __init__(self, **kwargs):
+        self.__showerID: Optional[str] = None
+        self.__primary: Optional[str] = None
+        self.__energy: Optional[u.Quantity] = None
+        self.__zenith: Optional[u.Quantity] = None
+        self.__azimuth: Optional[u.Quantity] = None
+
+        self._attributes = ("showerID", "primary", "energy", "zenith",
+                            "azimuth")
+
+        for attr, value in kwargs.items():
+            if attr not in self._attributes:
+                raise ValueError(f"Invalid attribute {attr}")
+            setattr(self, attr, value)
+
+
+    def __str__(self) -> str:
+        attributes = ", ".join([attr + "=" + repr(getattr(self, attr))
+                                for attr in self._attributes])
+        return f"CheckedShower({attributes})"
+
+
+    @staticmethod
+    def _assert_not_set(attr):
+        if attr is not None:
+            raise AlreadySet()
+
+
+    @property
+    def showerID(self) -> str:
+        """The very unique ID of a shower"""
+        return self.__showerID
+
+    @showerID.setter
+    def showerID(self, value: str):
+        self._assert_not_set(self.__showerID)
+        self.__showerID = value
+
+
+    @property
+    def primary(self) -> str:
+        """The primary particle initiating the shower"""
+        return self.__primary
+
+    @primary.setter
+    def primary(self, value: str):
+        self._assert_not_set(self.__primary)
+        self.__primary = value
+
+
+    @property
+    def energy(self) -> u.Quantity:
+        """The total energy contained in the shower"""
+        return self.__energy
+
+    @energy.setter
+    def energy(self, value: u.Quantity):
+        self._assert_not_set(self.__energy)
+        self.__energy = value.to(u.eV)
+
+
+    @property
+    def zenith(self) -> u.Quantity:
+        """The zenith angle of the shower axis"""
+        return self.__zenith
+
+    @zenith.setter
+    def zenith(self, value: u.Quantity):
+        self._assert_not_set(self.__zenith)
+        self.__zenith = value.to(u.deg)
+
+
+    @property
+    def azimuth(self) -> u.Quantity:
+        """The azimuth angle of the shower axis"""
+        return self.__azimuth
+
+    @azimuth.setter
+    def azimuth(self, value: u.Quantity):
+        self._assert_not_set(self.__azimuth)
+        self.__azimuth = value.to(u.deg)


### PR DESCRIPTION
Hello Anne :)

I just started to have a look at your new code. One thing that I noticed is that you are experimenting with Python classes used as containers, e.g. the `Shower` class. Note that there already exists containers factories in the STL, e.g. `namedtuples` which are efficient and might be enough in some situations.
This PR contains examples of those containers under `container_examples/namedtuple.py`.

Concerning type checking, the current trend is not to do this systematically at run-time, but instead to use mypy, a static analyser. You provide annotations of what type is expected and running mypy allows to cross-check that one indeed uses the right types, etc. There is an example provided, the `TypedShower`
using a `typing.NamedTuple`. I am using this in the `grand` package as well.

Now when more complex containers are needed, e.g. because you want to check the units of the provided attributes, one can indeed use a class as a container. Note however that in Python there is no privacy, i.e. any class attribute can be directly accessed. Therefore, in most cases it is irrelevant to define getters and setters, the like: `get_energy` and `set_energy`. Instead one uses a `@property` class decorator. Basically it allows to do what you want but in a more elegant way. The end user would just do:
```
shower.energy = 1E+019 * u.eV
```
But behind the scene it will be cross-checked that the provided value for the energy has the right unit. I provided a starting example as well in `container_examples/property.py`. In this example it is checked
that each attribute is set at most once. The unit check is done implictly by doing a conversion to the desired default unit, e.g. `value.to(u.eV)`. If `value` has an inconsistent unit then an error is raised by `astropy`.

Finally, concerning units. It's zooper easy :P You only need to import `astropy.units` (as `u` is customary) then you can do things like:
```
a = np.array((1, 2, 3)) * u.m
```
The array `a` will be of type `u.Quantity` which derives from a numpy.array but has an extra unit attached to it. All values of the array have the same unit.

Cheers,

Valentin

P.S: you can run the examples as `python3.7 -m container_examples` from the `lib/python/radio-simus` directory.
P.S.2: You could merge this to a separate branch not to spoil your main code. Our just copy paste around from GitHub.
